### PR TITLE
Detect SSE3 via CPUID

### DIFF
--- a/src/Env.cpp
+++ b/src/Env.cpp
@@ -28,6 +28,10 @@ ComputeEnv::ComputeEnv()
 #endif
 	this->flags = 0;
 
+	if (ecx & (1<<0)) {
+		this->flags |= ComputeEnv::HAVE_CPU_SSE3;
+	}
+
 	if ((ecx & 0x18000000) == 0x18000000) {
 		this->flags |= ComputeEnv::HAVE_CPU_AVX;
 	}

--- a/src/Env.hpp
+++ b/src/Env.hpp
@@ -19,6 +19,7 @@ struct ComputeEnv {
 
     static const int HAVE_CPU_FMA = 1<<0;
     static const int HAVE_CPU_AVX = 1<<1;
+    static const int HAVE_CPU_SSE3 = 1<<2;
 
     int flags;
 


### PR DESCRIPTION
Restores non-SSE3 support after 5138710. Only tested with SSE3 available:

```
CPU: Intel(R) Core(TM)2 Quad  CPU   Q9450  @ 2.66GHz
```
