### PR TITLE
cmake: make install + make test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,3 +187,24 @@ add_custom_target(gensrcs ALL
 
 add_executable(runtest w32-apps/runtest.c)
 target_link_libraries(runtest w2xc)
+
+install(TARGETS w2xc waifu2x-converter-cpp
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION "lib${LIB_SUFFIX}"
+  ARCHIVE DESTINATION "lib${LIB_SUFFIX}"
+)
+install(FILES src/w2xconv.h DESTINATION include)
+
+# Better add support for multiple directories where to find models
+# with paths separated by : (a la PATH) then install unconditionally
+option(INSTALL_MODELS "Install waifu2x RGB models" false)
+if(INSTALL_MODELS)
+  add_definitions(-DDEFAULT_MODELS_DIRECTORY="${CMAKE_INSTALL_PREFIX}/share/waifu2x-converter-cpp")
+  install(DIRECTORY models_rgb/ DESTINATION share/waifu2x-converter-cpp)
+endif()
+
+option(INSTALL_DOCS "Install developer documentation" false)
+if(INSTALL_DOCS)
+  install(DIRECTORY appendix docs/internals
+    DESTINATION share/doc/waifu2x-converter-cpp)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,8 +185,10 @@ endif()
 add_custom_target(gensrcs ALL
   DEPENDS ${GPU_CODE})
 
+enable_testing()
 add_executable(runtest w32-apps/runtest.c)
 target_link_libraries(runtest w2xc)
+add_test(runtest runtest)
 
 install(TARGETS w2xc waifu2x-converter-cpp
   RUNTIME DESTINATION bin

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,10 @@
 
 #include "w2xconv.h"
 
+#ifndef DEFAULT_MODELS_DIRECTORY
+#define DEFAULT_MODELS_DIRECTORY "models_rgb"
+#endif
+
 int main(int argc, char** argv) {
 	int ret = 1;
 
@@ -52,7 +56,7 @@ int main(int argc, char** argv) {
 
 	TCLAP::ValueArg<std::string> cmdModelPath("", "model_dir",
 			"path to custom model directory (don't append last / )", false,
-			"models_rgb", "string", cmd);
+			DEFAULT_MODELS_DIRECTORY, "string", cmd);
 
 	TCLAP::ValueArg<int> cmdNumberOfJobs("j", "jobs",
 			"number of threads launching at the same time", false, 0, "integer",


### PR DESCRIPTION
Working `make install` can be useful in order to help **new** downstream figure out which files to install. This slightly increases the cost of maintenance but probably won't be an issue unless you add new model (e.g. nagadomi/waifu2x@95e9d27).

Existing downstream can adapt like freebsd/freebsd-ports@5e8b457 or the following patch (CC'ing @ctrlcctrlv).

``` diff
--- waifu2x-git/PKGBUILD~   4f9ec14
+++ waifu2x-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Fredrick Brennan <admin@8chan.co>
 pkgname=waifu2x-git
-pkgver=r260.2ca9d90
+pkgver=r262.6f0fdc6
 pkgrel=1
 pkgdesc="Image rescaling and noise reduction using the power of convolutional neural networks"
 arch=('x86_64')
@@ -22,9 +22,8 @@ md5sums=('SKIP') #generate with 'makepkg
 gitreponame="waifu2x-converter-cpp"

 prepare() {
-  cd $gitreponame
-
-  patch -Np1 -i ../../arch_use_usr_share_for_models.patch
+  # Adjust binary name and models directory according to provides()
+  sed -i "s/$provides[2]/$provides[1]/" $gitreponame/CMakeLists.txt
 }

 build() {
@@ -32,19 +31,13 @@ build() {
   #
   # BUILD HERE
   #
-  cmake .
+  cmake -DINSTALL_MODELS=on .
   make
 }

 package() {
-  ## Waifu2x's Makefile has no `install`
-  ## Just copy its binary, and some files it require...
-  install -D $gitreponame/$gitreponame $pkgdir/usr/bin/waifu2x
-  install -D $gitreponame/libw2xc.so $pkgdir/usr/lib/libw2xc.so
+  make install -C$gitreponame
   install -D ../waifu2x.1.gz $pkgdir/usr/share/man/man1/waifu2x.1.gz
-  install -D $gitreponame/src/w2xconv.h $pkgdir/usr/include/w2xconv.h
-  mkdir -p $pkgdir/usr/share/waifu2x || true
-  cp -r $gitreponame/models_rgb $pkgdir/usr/share/waifu2x
 }

 # From https://wiki.archlinux.org/index.php/VCS_package_guidelines#Git
@@ -54,9 +47,8 @@ pkgver() {
 }

 check() {
-  cd $gitreponame
   msg 'Running Waifu2x'\''s test suite. Depending on your processor and GPU, this may take a while.'
-  ./runtest
+  make test ARGS="-V" -C$gitreponame
 }

 # vim:set ts=2 sw=2 et:
```
