### PR TITLE
use of cstring not string

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
-#include <string>
+#include <cstring>
 #include <cmath>
 #include "tclap/CmdLine.h"
 #include "sec.hpp"


### PR DESCRIPTION
With the Arch Linux aur package waifu2x-git there is a compile error.

[ 95%] Built target runtest
/var/abs/local/yaourtbuild/waifu2x-git/src/waifu2x-converter-cpp/src/main.cpp: In function ‘int main(int, char*_)’:
/var/abs/local/yaourtbuild/waifu2x-git/src/waifu2x-converter-cpp/src/main.cpp:77:42: error: ‘strcmp’ was not declared in this scope
   if (strcmp(argv[ai], "--list-processor") == 0) {
                                                 ^
CMakeFiles/waifu2x.dir/build.make:62: recipe for target 'CMakeFiles/waifu2x.dir/src/main.cpp.o' failed
make[2]: *_\* [CMakeFiles/waifu2x.dir/src/main.cpp.o] Error 1
CMakeFiles/Makefile2:215: recipe for target 'CMakeFiles/waifu2x.dir/all' failed
make[1]: **\* [CMakeFiles/waifu2x.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: **\* [all] Error 2
==> ERROR: A failure occurred in build().
Aborting...
:: waifu2x-git cleaning skipped
:: failed to build waifu2x-git package(s)

I'am unsure of any effect this has on other platforms, but this solves it entirely for me. Maybe this could be added the the pkgbuild
at least with some sed magic. If not not acceptable or causes issues I'am unaware of.
