### PR TITLE
More non-x86 support

### DIFF
--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -6,7 +6,6 @@
 //#if (defined __GNUC__) || (defined __clang__)
 #ifndef _WIN32
 #include <cpuid.h>
-#include <unistd.h>
 #endif
 #endif // X86OPT
 #include "w2xconv.h"

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -71,8 +71,6 @@ global_init2(void)
 			}
 		} else if (v[2] & (1<<0)) {
 			host.sub_type = W2XCONV_PROC_HOST_SSE3;
-		} else {
-			host.sub_type = W2XCONV_PROC_OPENCL;
 		}
 
 		processor_list.push_back(host);

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -35,8 +35,10 @@ global_init2(void)
 		W2XConvProcessor host;
 		host.type = W2XCONV_PROC_HOST;
 		host.dev_id = 0;
+		host.dev_name = "Generic";
 		host.num_core = std::thread::hardware_concurrency();
 
+#ifdef X86OPT
 #ifdef _WIN32
 #define x_cpuid(p,eax) __cpuid(p, eax)
 		typedef int cpuid_t;
@@ -72,6 +74,7 @@ global_init2(void)
 		} else if (v[2] & (1<<0)) {
 			host.sub_type = W2XCONV_PROC_HOST_SSE3;
 		}
+#endif // X86OPT
 
 		processor_list.push_back(host);
 	}


### PR DESCRIPTION
Non-x86 build have regressed. It can also be triggered by `cmake -DX86OPT=off`.

``` c++
src/w2xconv.cpp:50:3: error: use of undeclared identifier '__get_cpuid'
                x_cpuid(v, 0x80000000);
                ^
src/w2xconv.cpp:44:24: note: expanded from macro 'x_cpuid'
#define x_cpuid(p,eax) __get_cpuid(eax, &(p)[0], &(p)[1], &(p)[2], &(p)[3]);
                       ^
src/w2xconv.cpp:52:4: error: use of undeclared identifier '__get_cpuid'
                        x_cpuid(data+4*0, 0x80000002);
                        ^
src/w2xconv.cpp:44:24: note: expanded from macro 'x_cpuid'
#define x_cpuid(p,eax) __get_cpuid(eax, &(p)[0], &(p)[1], &(p)[2], &(p)[3]);
                       ^
src/w2xconv.cpp:53:4: error: use of undeclared identifier '__get_cpuid'
                        x_cpuid(data+4*1, 0x80000003);
                        ^
src/w2xconv.cpp:44:24: note: expanded from macro 'x_cpuid'
#define x_cpuid(p,eax) __get_cpuid(eax, &(p)[0], &(p)[1], &(p)[2], &(p)[3]);
                       ^
src/w2xconv.cpp:54:4: error: use of undeclared identifier '__get_cpuid'
                        x_cpuid(data+4*2, 0x80000004);
                        ^
src/w2xconv.cpp:44:24: note: expanded from macro 'x_cpuid'
#define x_cpuid(p,eax) __get_cpuid(eax, &(p)[0], &(p)[1], &(p)[2], &(p)[3]);
                       ^
src/w2xconv.cpp:59:4: error: use of undeclared identifier '__get_cpuid'
                        x_cpuid(data, 0x0);
                        ^
src/w2xconv.cpp:44:24: note: expanded from macro 'x_cpuid'
#define x_cpuid(p,eax) __get_cpuid(eax, &(p)[0], &(p)[1], &(p)[2], &(p)[3]);
                       ^
src/w2xconv.cpp:64:3: error: use of undeclared identifier '__get_cpuid'
                x_cpuid(v, 1);
                ^
```

After the fix (see also [build.log](https://gist.github.com/jbeich/ce314c3f8c8d4b116f14)):

``` shell
# local default
$ waifu2x-converter-cpp --list-processor
   0: Intel(R) Core(TM)2 Quad  CPU   Q9450  @ 2.66GHz(SSE3      ): num_core=4

# armv6 via qemu-user-static
$ waifu2x-converter-cpp --list-processor
   0: Generic                                      (OpenCV    ): num_core=4

# -DX86OPT=off + freeocl
$ waifu2x-converter-cpp --list-processor
sysctl: unknown oid 'kernel.ostype': No such file or directory
   0: Generic                                      (OpenCV    ): num_core=4
   1:                                              (OpenCL    ): num_core=0
```
