### PR TITLE
Fix miscellaneous regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,24 @@ include(CheckIncludeFileCXX)
 pkg_check_modules(OPENCV_PKG opencv)
 
 if (${OPENCV_PKG_FOUND})
-  include_directories(${OPENCV_PKG_PREFIX}/include)
+  set(CMAKE_REQUIRED_INCLUDES ${OPENCV_PKG_INCLUDE_DIRS})
+  include_directories(${OPENCV_PKG_INCLUDE_DIRS})
+  link_directories(${OPENCV_PKG_LIBRARY_DIRS})
 else()
   set(OPENCV_PREFIX "/usr"
     CACHE FILEPATH "OpenCV 2.x path")
+  set(CMAKE_REQUIRED_INCLUDES ${OPENCV_PREFIX}/include)
   include_directories(${OPENCV_PREFIX}/include)
+  link_directories(${OPENCV_PREFIX}/lib)
 endif()
 
 check_include_file_cxx("opencv2/opencv.hpp" HAVE_OPENCV)
+find_library(IMGCODECS_LIBRARY NAMES opencv_imgcodecs opencv_highgui
+  HINTS ${OPENCV_PKG_INCLUDE_DIRS} ${OPENCV_PREFIX}/lib)
 
 if(HAVE_OPENCV)
   add_definitions(-DHAVE_OPENCV)
-else()
-  
+  set(OPENCV_LIBRARIES opencv_core opencv_imgproc ${IMGCODECS_LIBRARY} opencv_features2d)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
@@ -68,12 +73,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   endif()
 
   link_directories(${OPENCV_PREFIX}/${OCV_SYSTEM_DIRNAME}/${OCV_COMPILER_DIRNAME}/staticlib)
-else()
-  link_directories(${OPENCV_PREFIX}/lib)
 endif()
-
-find_library(IMGCODECS_LIBRARY NAMES opencv_imgcodecs opencv_highgui
-  HINTS ${OPENCV_PREFIX}/lib)
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR
     CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR
@@ -182,7 +182,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   add_executable(w2xcr WIN32 w32-apps/w2xcr.c)
   target_link_libraries(w2xcr w2xc user32 shlwapi gdi32)
 else()
-  target_link_libraries(w2xc opencv_core opencv_imgproc ${IMGCODECS_LIBRARY} opencv_features2d pthread dl)
+  target_link_libraries(w2xc ${OPENCV_LIBRARIES} ${CMAKE_DL_LIBS} pthread)
 endif()
 
 set(CONV_EXE "$<TARGET_FILE_DIR:conv>/conv")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,9 @@ else()
   message(WARNING "cuda not found. disabled.")
 endif()
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   if(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
FreeBSD [aarch64](https://gist.github.com/jbeich/ce314c3f8c8d4b116f14#file-aarch64-log) via qemu-user-static

``` shell
$ waifu2x-converter-cpp --list-processor
   0: ARM NEON                                     (NEON      ): num_core=1
```

Android armv7 (lost `libOpenCL.so` after upgrade)

``` shell
$ ./runbench
ARM NEON
start process block (0,0) ...
Iteration #1(1->32)...(108.551[ms], 1.46811[GFLOPS], 0.336443[GB/s])
Iteration #2(32->32)...(682.831[ms], 7.46846[GFLOPS], 0.103729[GB/s])
Iteration #3(32->64)...(1223.82[ms], 8.33408[GFLOPS], 0.0868134[GB/s])
Iteration #4(64->64)...(2546.26[ms], 8.01125[GFLOPS], 0.0556337[GB/s])
Iteration #5(64->128)...(4842.56[ms], 8.42479[GFLOPS], 0.0438791[GB/s])
Iteration #6(128->128)...(10459.9[ms], 7.80073[GFLOPS], 0.0270859[GB/s])
Iteration #7(128->1)...(167.419[ms], 3.80757[GFLOPS], 0.852737[GB/s])
total : 20.0322[sec], 7.9316[GFLOPS]
```
